### PR TITLE
fix: adds valid urns for ocpp rpc schemas

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "typescript-eslint": "^7.4.0"
   },
   "dependencies": {
-    "ajv": "^8.12.0",
+    "ajv": "^8.17.1",
     "ajv-formats": "^2.1.1"
   },
   "directories": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,11 +6,11 @@ settings:
 
 dependencies:
   ajv:
-    specifier: ^8.12.0
-    version: 8.12.0
+    specifier: ^8.17.1
+    version: 8.17.1
   ajv-formats:
     specifier: ^2.1.1
-    version: 2.1.1(ajv@8.12.0)
+    version: 2.1.1(ajv@8.17.1)
 
 devDependencies:
   '@jest/globals':
@@ -1322,7 +1322,7 @@ packages:
     hasBin: true
     dev: true
 
-  /ajv-formats@2.1.1(ajv@8.12.0):
+  /ajv-formats@2.1.1(ajv@8.17.1):
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
     peerDependencies:
       ajv: ^8.0.0
@@ -1330,7 +1330,7 @@ packages:
       ajv:
         optional: true
     dependencies:
-      ajv: 8.12.0
+      ajv: 8.17.1
     dev: false
 
   /ajv@6.12.6:
@@ -1342,13 +1342,13 @@ packages:
       uri-js: 4.4.1
     dev: true
 
-  /ajv@8.12.0:
-    resolution: {integrity: sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==}
+  /ajv@8.17.1:
+    resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
     dependencies:
       fast-deep-equal: 3.1.3
+      fast-uri: 3.0.1
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
-      uri-js: 4.4.1
     dev: false
 
   /ansi-escapes@4.3.2:
@@ -2522,6 +2522,10 @@ packages:
   /fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
     dev: true
+
+  /fast-uri@3.0.1:
+    resolution: {integrity: sha512-MWipKbbYiYI0UC7cl8m/i/IWTqfC8YXsqjzybjddLsFjStroQzsHXkc73JutMvBiXmOvapk+axIl79ig5t55Bw==}
+    dev: false
 
   /fastq@1.17.1:
     resolution: {integrity: sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==}
@@ -4023,6 +4027,7 @@ packages:
   /punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+    dev: true
 
   /pure-rand@6.0.4:
     resolution: {integrity: sha512-LA0Y9kxMYv47GIPJy6MI84fqTd2HmYZI83W/kM/SkKfDlajnZYfmXFTxkbY+xSBPkLJxltMa9hIkmdc29eguMA==}
@@ -4638,6 +4643,7 @@ packages:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
     dependencies:
       punycode: 2.3.1
+    dev: true
 
   /v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}

--- a/src/schemas/v16/rpc-call-error.json
+++ b/src/schemas/v16/rpc-call-error.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "urn:RpcCallErrorV16",
+  "$id": "urn:OCPP:1.6:2019:12:RpcCallErrorV16",
   "title": "RpcCallError",
   "type": "array",
   "minItems": 5,

--- a/src/schemas/v16/rpc-call-result.json
+++ b/src/schemas/v16/rpc-call-result.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "urn:RpcCallResultV16",
+  "$id": "urn:OCPP:1.6:2019:12:RpcCallResultV16",
   "title": "RpcCallResult",
   "type": "array",
   "minItems": 3,

--- a/src/schemas/v16/rpc-call.json
+++ b/src/schemas/v16/rpc-call.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "urn:RpcCallV16",
+  "$id": "urn:OCPP:1.6:2019:12:RpcCallV16",
   "title": "RpcCall",
   "type": "array",
   "minItems": 4,

--- a/src/schemas/v201/rpc-call-error.json
+++ b/src/schemas/v201/rpc-call-error.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "urn:RpcCallErrorV201",
+  "$id": "urn:OCPP:Cp:2:2020:3:RpcCallErrorV201",
   "title": "RpcCallError",
   "type": "array",
   "minItems": 5,

--- a/src/schemas/v201/rpc-call-result.json
+++ b/src/schemas/v201/rpc-call-result.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "urn:RpcCallResultV201",
+  "$id": "urn:OCPP:Cp:2:2020:3:RpcCallResultV201",
   "title": "RpcCallResult",
   "type": "array",
   "minItems": 3,

--- a/src/schemas/v201/rpc-call.json
+++ b/src/schemas/v201/rpc-call.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "urn:RpcCallV201",
+  "$id": "urn:OCPP:Cp:2:2020:3:RpcCallV201",
   "title": "RpcCall",
   "type": "array",
   "minItems": 4,

--- a/tests/ocpp-messages-v16.test.ts
+++ b/tests/ocpp-messages-v16.test.ts
@@ -51,6 +51,15 @@ const exampleRequests: Array<TestCase<OCPPCallV16>> = [
       action: "SecurityEventNotification",
       payload: { timestamp: "2024-04-25T23:04:15Z", type: "InvalidMessages" }
     }
+  },
+  {
+    input: "[2,\"829cc6c0-25c8-4a8c-a7fb-ad31fb25d66b\",\"StatusNotification\",{\"connectorId\":2,\"status\":\"Available\",\"errorCode\":\"NoError\"}]",
+    expected: {
+      messageId: "829cc6c0-25c8-4a8c-a7fb-ad31fb25d66b",
+      messageTypeId: 2,
+      action: "StatusNotification",
+      payload: { connectorId: 2, status: "Available", errorCode: "NoError" }
+    }
   }
 ];
 


### PR DESCRIPTION
ajv version 8.17 uses fast-uri, that require's a valid URN format.